### PR TITLE
デフォルト値を伴わないキーワード引数がruby2.0ではsyntax errorになるので nil をデフォルト引数にしました

### DIFF
--- a/lib/japan_net_bank/transfer/row.rb
+++ b/lib/japan_net_bank/transfer/row.rb
@@ -23,7 +23,7 @@ module JapanNetBank
               greater_than_or_equal_to: 1
           }
 
-      def initialize(record_type: RECORD_TYPE_DATA, bank_code:, branch_code:, account_type:, number:, name:, amount:)
+      def initialize(record_type: RECORD_TYPE_DATA, bank_code: nil, branch_code: nil, account_type: nil, number: nil, name: nil, amount: nil)
         @record_type  = record_type
         @bank_code    = bank_code
         @branch_code  = branch_code


### PR DESCRIPTION
@inouetakuya 

cc: @takatoshiono @gs3 @f-kubotar 

デフォルト値を伴わないキーワード引数がruby2.0ではsyntax errorになるので nil をデフォルト引数にしました。
( 2.0 つかっていてすいません... )

引数のバリデーション自体は ActiveModel でおこなっているので、キーワード引数のデフォルト値自体はnilでも問題無いと思います。
