### PR TITLE
`JapanNetBank::Transfer#row_array_to_hash`内のsprintfの第二引数に"0123456"のような文字列がきたときに8進数として扱われるので修正した

### DIFF
--- a/lib/japan_net_bank/transfer.rb
+++ b/lib/japan_net_bank/transfer.rb
@@ -131,10 +131,10 @@ module JapanNetBank
     def row_array_to_hash(row_array)
       {
           record_type:  row_array[0],
-          bank_code:    sprintf('%04d', row_array[1]),
-          branch_code:  sprintf('%03d', row_array[2]),
+          bank_code:    sprintf('%04d', row_array[1].to_i),
+          branch_code:  sprintf('%03d', row_array[2].to_i),
           account_type: JapanNetBank::Transfer::Row::ACCOUNT_TYPES[row_array[3]],
-          number:       sprintf('%07d', row_array[4]),
+          number:       sprintf('%07d', row_array[4].to_i),
           name:         row_array[5],
           amount:       row_array[6],
       }


### PR DESCRIPTION
@inouetakuya @takatoshiono 

`JapanNetBank::Transfer#row_array_to_hash`内の口座番号の整形で、sprintfの第二引数に"0123456"のような文字列がきたときに8進数として扱われるので修正しました。
