### PR TITLE
明示的にrequireしないとJapanNetBank::Transferが利用できない問題を解決しました

### DIFF
--- a/lib/japan_net_bank.rb
+++ b/lib/japan_net_bank.rb
@@ -1,4 +1,5 @@
 require "japan_net_bank/version"
+require "japan_net_bank/transfer"
 
 module JapanNetBank
   BANK_CODE = '0033'


### PR DESCRIPTION
@inouetakuya @takatoshiono @gs3 
### 問題

`japan_net_bank` v0.0.5 を利用して、振込のCSVを生成しようとしたところ、

```
NameError: uninitialized constant JapanNetBank::Transfer
```

というエラーが発生しました。
明示的に`require 'japan_net_bank/transfer'`を記述しないと利用できないようです。
### 対応

`lib`直下の`japan_net_bank.rb`で`require`するようにしました。
