### PR TITLE
[WIP] csv にしたとき、口座番号などの数値は、クオートする

### DIFF
--- a/lib/japan_net_bank/transfer/csv.rb
+++ b/lib/japan_net_bank/transfer/csv.rb
@@ -4,7 +4,7 @@ module JapanNetBank
   class Transfer
     class CSV
       def self.generate
-        csv = ::CSV.new('', row_sep: "\r\n")
+        csv = ::CSV.new('', row_sep: "\r\n", force_quotes: true)
         yield(csv)
         csv.string
       end


### PR DESCRIPTION
CSVを出力したとき、口座番号や支店コードは、数値(ダブルクオートされない列) として出力されますが、次のような場合に問題になることがあります。
1. エクセルとかで開いたとき、`0123456` という値が、`123456` という6桁の数値として認識される
2. 保存する
3. `123456` という6桁の文字列になる
4. そのデータで振込すると、6桁の口座番号がみつからないため失敗

そこで、口座番号は、数値ではなく文字列で扱いたい(ダブルクオートしたい)です。

疑問
- ジャパンネットバンクは値をダブルクオートしたcsv投げても大丈夫なのだろうか?
- ruby標準のcsvは、問答無用で `Integer(value) raise value` とかやるため、数値の文字列はクオートされない。特定の数値文字列だけをクォートする簡単な方法がない。たとえば、金額はクォートしない、口座番号はクォートする。ということができない
