### PR TITLE
Add :name_length_limit option to Transfer#to_csv

### DIFF
--- a/lib/japan_net_bank/transfer.rb
+++ b/lib/japan_net_bank/transfer.rb
@@ -104,10 +104,10 @@ module JapanNetBank
       append_row(row)
     end
 
-    def to_csv
+    def to_csv(opts = {})
       JapanNetBank::Transfer::CSV.generate do |csv|
         @rows.each do |row|
-          csv << row.to_a
+          csv << row.to_a(**opts)
         end
 
         csv << trailer_row if @rows_count > 0

--- a/lib/japan_net_bank/transfer/row.rb
+++ b/lib/japan_net_bank/transfer/row.rb
@@ -31,15 +31,17 @@ module JapanNetBank
         raise ArgumentError, errors.full_messages unless valid?
       end
 
-      def to_a
+      def to_a(name_length_limit: 48)
+        name = convert_to_hankaku_katakana(@name).slice(0, name_length_limit)
+
         [
-            @record_type,
-            @bank_code,
-            @branch_code,
-            account_type_code,
-            @number,
-            convert_to_hankaku_katakana(@name).encode('Shift_JIS'),
-            @amount.to_s,
+          @record_type,
+          @bank_code,
+          @branch_code,
+          account_type_code,
+          @number,
+          name.encode('Shift_JIS'),
+          @amount.to_s,
         ]
       end
 


### PR DESCRIPTION
#### Problem

Due to the limitation of bank systems, holder names length need to be shorter than or equal to 48. It raises an error on importing CSV if it is longer than that.

#### Solution

This PR adds an option `:name_length_limit` to `Transfer#to_csv` which is 48 by default. The reason why it is not fixed value is sometimes different length is preferred. Actually we now have use case that names on CSV must be shorter than 30.